### PR TITLE
test against 0.4 and 0.5 separately on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
`release` will soon change to 0.5, so add 0.4 explicitly to continue testing there
0.5 currently means the latest rc, but will mean the latest 0.5.x release once final is out
