### PR TITLE
Change deprecated eye function to new I function

### DIFF
--- a/src/projective.jl
+++ b/src/projective.jl
@@ -270,17 +270,8 @@ function cameraproject(C::Camera, pta::Array; computevisibility = false)
     # If C.rows and C.cols not empty determine points that are within image bounds
     if computevisibility 
         if C.rows !=0 && C.cols != 0
-# v0.6 code to be reinstated when 0.5 is retired
-#            visible = (x_p .>= 1.0) .& (x_p .<= convert(Float64,C.cols)) .&
-#                      (y_p .>= 1.0) .& (y_p .<= convert(Float64,C.rows))
-
-# Interim code that runs under 0.5 and 0.6
-            visible = Array{Bool}(undef, length(x_p))
-            for n = 1:length(x_p)
-                visible[n] = (x_p[n] >= 1.0) && (x_p[n] <= convert(Float64,C.cols)) &&
-                             (y_p[n] >= 1.0) && (y_p[n] <= convert(Float64,C.rows))
-            end
-
+           visible = (x_p .>= 1.0) .& (x_p .<= convert(Float64,C.cols)) .&
+                     (y_p .>= 1.0) .& (y_p .<= convert(Float64,C.rows))
         else
             @warn("Point visibility requested but Camera structure has no image size data")
             visible = Array{Bool}(undef, 0)

--- a/src/projective.jl
+++ b/src/projective.jl
@@ -120,7 +120,7 @@ end
 function Camera(;fx=1.0, fy=1.0, ppx=0.0, ppy=0.0,
                 k1=0.0, k2=0.0, k3=0.0, p1=0.0, p2=0.0, skew=0.0,
                 rows=0, cols=0,
-                P=[0.0, 0.0, 0.0], Rc_w=eye(3))
+                P=[0.0, 0.0, 0.0], Rc_w=I(3))
     if size(P) != (3,)
         error("Camera position must be a 3x1 array")
     end
@@ -1069,7 +1069,7 @@ function normalise1dpts(ptsa::Array{T1,2}) where T1 <: Real
 
     if any(pts[2,:] .== 0)
         @warn("Attempt to normalise a point at infinity")
-        return pts, eye(2)
+        return pts, I(2)
     end
     
     # Ensure homogeneous coords have scale of 1

--- a/src/projective.jl
+++ b/src/projective.jl
@@ -120,7 +120,7 @@ end
 function Camera(;fx=1.0, fy=1.0, ppx=0.0, ppy=0.0,
                 k1=0.0, k2=0.0, k3=0.0, p1=0.0, p2=0.0, skew=0.0,
                 rows=0, cols=0,
-                P=[0.0, 0.0, 0.0], Rc_w=eye(3))
+                P=[0.0, 0.0, 0.0], I(3))
     if size(P) != (3,)
         error("Camera position must be a 3x1 array")
     end
@@ -1069,7 +1069,7 @@ function normalise1dpts(ptsa::Array{T1,2}) where T1 <: Real
 
     if any(pts[2,:] .== 0)
         @warn("Attempt to normalise a point at infinity")
-        return pts, eye(2)
+        return pts, I(2)
     end
     
     # Ensure homogeneous coords have scale of 1

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -351,14 +351,7 @@ function nonmaxsuppts(cimg::Array{T,2}; radius::Real=1, thresh::Real=0,
     bordermask[radius+1:end-radius, radius+1:end-radius] .= true
     
     # Find maxima, threshold, and apply bordermask
-# v0.6 code to be reinstated when 0.5 goes away
-#    cimgmx = (cimg.==mx) .& (cimg.>thresh) .& bordermask
-
-# Interim code that runs under 0.5 and 0.6 ** check for 0.7**
-    cimgmx = zeros(Bool, rows, cols)
-    for c = 1:cols, r = 1:rows
-        cimgmx[r,c] = (cimg[r,c] == mx[r,c]) && (cimg[r,c] > thresh) && bordermask[r,c]
-    end
+    cimgmx = (cimg.==mx) .& (cimg.>thresh) .& bordermask
 
     
     # Get row, col coords of points.  The following is a clumsy replacement of
@@ -1417,22 +1410,9 @@ function matchbycorrelation(img1i, p1, img2i, p2, w, dmax=Inf)
         
         # Find indices of points that are distance 'r' or greater from
         # boundary on image1 and image2;
-# v0.6 code to be reinstated when 0.5 is retired
-#        n1ind = find((p1[1,:].>r) .& (p1[1,:].<im1rows+1-r) .& (p1[2,:].>r) .& (p1[2,:].<im1cols+1-r))
-#        n2ind = find((p2[1,:].>r) .& (p2[1,:].<im2rows+1-r) .& (p2[2,:].>r) .& (p2[2,:].<im2cols+1-r))
+        n1ind = find((p1[1,:].>r) .& (p1[1,:].<im1rows+1-r) .& (p1[2,:].>r) .& (p1[2,:].<im1cols+1-r))
+        n2ind = find((p2[1,:].>r) .& (p2[1,:].<im2rows+1-r) .& (p2[2,:].>r) .& (p2[2,:].<im2cols+1-r))
 
-# interim code that runs under 0.5 and 0.6        
-        tmp = Array{Bool}(undef, npts1)
-        for n = 1:npts1
-            tmp[n] = (p1[1,n]>r) && (p1[1,n]<im1rows+1-r) && (p1[2,n]>r) && (p1[2,n]<im1cols+1-r)
-        end
-        n1ind = findall(tmp)
-
-        tmp = Array{Bool}(undef, npts2)
-        for n = 1:npts2
-            tmp[n] = (p2[1,n]>r) && (p2[1,n]<im2rows+1-r) && (p2[2,n]>r) && (p2[2,n]<im2cols+1-r)
-        end
-        n2ind = findall(tmp)
 
 
 


### PR DESCRIPTION
Hello,

I just realized, that the `eye` function, that is used in two places, is not supported by new versions of Julia. After 1.0 I think. Just a small fix, two occurrences.

`I` is the replacement, which in this version returns a binary array. It worked as a replacement in the tests I did and the unit tests also passed. If you want, I can convert the result to `Float64` arrays.

Thanks for the great lib!