### PR TITLE
Fix solvestereopt for Camera struct input

### DIFF
--- a/src/projective.jl
+++ b/src/projective.jl
@@ -1903,7 +1903,7 @@ function solvestereopt(xy::Array{T,2}, C::Array{Camera}; reprojecterror=false) w
     # Correct image points from each camera so that they correspond to image
     # points from an ideal camera with no lens distortion.  Also generate the
     # corresponding ideal projection matrices for each Camera structure
-    xyideal = zeros(size(xy)) # copy xy so that xy is not changed
+    xyideal = similar(xy) # copy xy so that xy is not changed
     for n = 1:N
         xyideal[:,n] = idealimagepts(C[n], xy[:,n])
     end

--- a/src/projective.jl
+++ b/src/projective.jl
@@ -1906,8 +1906,8 @@ function solvestereopt(xy::Array{T,2}, C::Array{Camera}; reprojecterror=false) w
     xyideal = zeros(size(xy)) # copy xy so that xy is not changed
     for n = 1:N
         xyideal[:,n] = idealimagepts(C[n], xy[:,n])
-        P[n] = camstruct2projmatrix(C[n])
     end
+    P = [camera2projmatrix(c) for c in C]
 
     return solvestereopt(xyideal, P, reprojecterror=reprojecterror)
 end


### PR DESCRIPTION
There were some minor issues, that prevented the `solvestereopt(xy::Array{T,2}, C::Array{Camera}; reprojecterror=false)` function from working. A missing initialization of a variable and the use of a renamed function. Tested in my application, but no unit tests (yet).