### PR TITLE
Add unit test for solvestereopt

### DIFF
--- a/test/test_projective.jl
+++ b/test/test_projective.jl
@@ -142,3 +142,10 @@ F1 = F1/F1[3,3]  # Adjust matrices to the same scale
 F2 = F2/F2[3,3]
 
 @test maximum(abs.(F1 - F2)) < tol
+
+# solvestereopt
+res = []
+for i in 1:12
+          push!(res, maximum(makeinhomogeneous(solvestereopt([xy1[:,i] xy2[:,i]], [Cam1, Cam2])) .- pts[:,i] ) < tol)
+end
+@test all(res)


### PR DESCRIPTION
Hey,

I have been working with your lib recently and found some minor issues I tried to fix.

This merge request adds a unit test, that should cover the entire chain of converting a Camera struct to a projection matrix and solving the stereo problem. Are you fine with the style of the code? I am not completely happy but lack a better idea. Maybe have the `@test` makro in the loop.

Hope I can help!