### PR TITLE
replace deprecated A_mul_B! with mul!

### DIFF
--- a/src/projective.jl
+++ b/src/projective.jl
@@ -528,7 +528,7 @@ function imagept2ray!(ray, C::Camera, x, y)
     # in terms of the camera frame.  Rotate to get the viewing rays in
     # the world frame 
     # ray = C.Rc_w'*ray
-    A_mul_B!(ray, C.Rc_w', [x_n, y_n, 1])
+    mul!(ray, C.Rc_w', [x_n, y_n, 1])
 
     normalize!(ray)
     return ray

--- a/test/test_projective.jl
+++ b/test/test_projective.jl
@@ -155,7 +155,7 @@ end
 res = []
 for i in 1:12
      dist = norm(pts[:,i] - Cam1.P)
-     ray = normalize(imagept2ray(Cam1, xy1[1,i], xy1[2,i]))
+     ray = imagept2ray(Cam1, xy1[1,i], xy1[2,i])
      target = dist * ray + Cam1.P
      push!(res, norm(target - pts[:,i]) < tol)
 end

--- a/test/test_projective.jl
+++ b/test/test_projective.jl
@@ -149,3 +149,15 @@ for i in 1:12
           push!(res, maximum(makeinhomogeneous(solvestereopt([xy1[:,i] xy2[:,i]], [Cam1, Cam2])) .- pts[:,i] ) < tol)
 end
 @test all(res)
+
+# imagept2ray
+# construct rays for projected image coordinates and compare with original points
+res = []
+for i in 1:12
+     dist = norm(pts[:,i] - Cam1.P)
+     ray = normalize(imagept2ray(Cam1, xy1[1,i], xy1[2,i]))
+     target = dist * ray + Cam1.P
+     push!(res, norm(target - pts[:,i]) < tol)
+end
+@test all(res)
+


### PR DESCRIPTION
Hello!

While working with Julia 1.7.1, I realized that the function `A_mul_B!` was deprecated and is no longer available. It is only used in one place, the `imagept2ray` function. The [deprecation](https://github.com/JuliaLang/julia/blob/029fb723c08530d6a9fadb61cb84f5c1b6cc3402/stdlib/LinearAlgebra/src/deprecated.jl#L680) uses `mul!` as replacement, which I implemented.

The tests still passed, though there is no test for the changed function ;)

Thanks for considering the contribution and best regards
Paul