### PR TITLE
make imagept2plane with camera matrix compatible with struct version

### DIFF
--- a/src/projective.jl
+++ b/src/projective.jl
@@ -369,6 +369,18 @@ end
 
 # Case when the camera is represented by a projection matrix
 
+function imagept2plane(Proj::Array, cameraP::Vector, xy::Array, planeP::Vector, planeN::Vector)
+    (dim, N) = (size(xy,1), size(xy,2))  # xy might be a Vector
+    if dim != 2
+        error("Image xy data must be a 2 x N array")
+    end
+    res = zeros(3, N)
+    for i in 1:N
+        res[:,N] = imagept2plane(Proj, cameraP, xy[:,i], planeP, planeN)
+    end
+    res
+end
+
 function imagept2plane(Proj::Array, cameraP::Vector, xy::Vector, planeP::Vector, planeN::Vector)
     
     if size(Proj) != (3,4) 

--- a/test/test_projective.jl
+++ b/test/test_projective.jl
@@ -51,6 +51,10 @@ P = camera2projmatrix(Cam)
 @test abs(K[1,3] - ppx) < rows*tol
 @test abs(K[2,3] - ppy) < rows*tol
 
+# imagept2plane with camera matrix
+planept = imagept2plane(P, Pc_d, xy, planeP, planeN)
+@test maximum(abs.(planept - [gpt1 gpt2])) < f*tol
+
 # makehomogeneous makeinhomoheneous hnormalise
 x = rand(2,4)
 hx = makehomogeneous(x)


### PR DESCRIPTION
Hey,

one more small fix with a test for that part of the code. The `imagept2plane` function that works with a camera matrix expected the `xy` input to be a vector (so only one point), while the version with the struct expects a matrix, so multiple points. This change adds the required overload to also allow multiple points.

The code was "inspired" by the other implementation, so I do not think there is anything very interesting in it.

Cheers and thanks
Paul