### PR TITLE
improve inverse distortion of imagept2plane from Camera construct (fix #31)

### DIFF
--- a/src/projective.jl
+++ b/src/projective.jl
@@ -112,7 +112,7 @@ mutable struct Camera
     rows::Int       # Optional, providing rows and columns allows detection
     cols::Int       # of points being projected out of image bounds.
     P::Vector{Float64}    # Camera position in world coordinates.
-    Rc_w::Array{Float64}  # Rotation matrix defining world orientation with
+    Rc_w::Matrix{Float64}  # Rotation matrix defining world orientation with
                           # respect to the camera frame.
 end
 

--- a/src/projective.jl
+++ b/src/projective.jl
@@ -345,8 +345,8 @@ function imagept2plane(C::Camera, xy::Array, planeP::Vector, planeN::Vector)
     # non-convergence of the mothod happens if an image point has no corresponding 
     # point on the plane, due to distortion. This is not caught currently
     
-    x_n=deepcopy(x_d)
-    y_n=deepcopy(y_d)
+    x_n = copy(x_d)
+    y_n = copy(y_d)
     for i=1:N
         trd=0.0
         rsq=0.0

--- a/src/projective.jl
+++ b/src/projective.jl
@@ -340,7 +340,8 @@ function imagept2plane(C::Camera, xy::Array, planeP::Vector, planeN::Vector)
     # distortion factor to get an approximation of the undistorted normalised
     # image coordinates (with no skew)
 
-    # inverse of the radial distortion is calculated by iteration
+    # inverse of the radial distortion is calculated by iteration 
+    # (see e.g., Drap&Lefèvre 2015, doi: 10.3390/s16060807)
     # non-convergence of the mothod happens if an image point has no corresponding 
     # point on the plane, due to distortion. This is not caught currently
     

--- a/src/projective.jl
+++ b/src/projective.jl
@@ -339,8 +339,26 @@ function imagept2plane(C::Camera, xy::Array, planeP::Vector, planeN::Vector)
     # Subtract the tangential distortion components and divide by the radial
     # distortion factor to get an approximation of the undistorted normalised
     # image coordinates (with no skew)
-    x_n = (x_d .- dtx)./r_d
-    y_n = (y_d .- dty)./r_d
+
+    # inverse of the radial distortion is calculated by iteration
+    # non-convergence of the mothod happens if an image point has no corresponding 
+    # point on the plane, due to distortion. This is not caught currently
+    
+    x_n=deepcopy(x_d)
+    y_n=deepcopy(y_d)
+    for i=1:N
+        trd=0.0
+        rsq=0.0
+        for _=1:100
+            rsq=x_n[i]^2+y_n[i]^2
+            trd = 1 + C.k1*rsq + C.k2*rsq^2 + C.k3*rsq^3
+            abs(x_n[i] - x_d[i]/trd) <1e-8 && abs(y_n[i] - y_d[i]/trd) <1e-8 && break #convergence check
+            x_n[i] = x_d[i] / trd
+            y_n[i] = y_d[i] / trd
+        end
+        x_n[i] = (x_d[i] - dtx[i]) / trd
+        y_n[i] = (y_d[i] - dty[i]) / trd
+    end
 
     # Define a set of points at the normalised distance of z = 1 from the
     # principal point, these define the viewing rays in terms of the camera

--- a/test/test_projective.jl
+++ b/test/test_projective.jl
@@ -34,10 +34,18 @@ gpt2 = [100.0, -200.0, 0.0]
 (xy, visible) = cameraproject(Cam, [gpt1 gpt2], computevisibility=true)  # project to image
 
 # Then project image points to ground plane to see if we reconstruct them
-# ** Note this does not seem to work with lens distortion
 planeP = [0.0,0.0,0.0]
 planeN = [0.0,0.0,1.0]
 planept = imagept2plane(Cam, xy, planeP, planeN)
+@test maximum(abs.(planept - [gpt1 gpt2])) < f*tol
+
+#same test as above with radial distortion
+Cam.k1=-0.2
+Cam.k2=0.2
+Cam.k3=-0.2
+
+xy = cameraproject(Cam, [gpt1 gpt2])
+planept = imagept2plane(Cam, xy, planeP, planeN,:iterative)
 @test maximum(abs.(planept - [gpt1 gpt2])) < f*tol
 
 # Convert Cam structure to projection matrix and decompose to see if we get the same parameters back

--- a/test/test_projective.jl
+++ b/test/test_projective.jl
@@ -40,10 +40,8 @@ planept = imagept2plane(Cam, xy, planeP, planeN)
 @test maximum(abs.(planept - [gpt1 gpt2])) < f*tol
 
 #same test as above with radial distortion
-dCam=deepcopy(Cam)
-dCam.k1=-0.2
-dCam.k2=0.2
-dCam.k3=-0.2
+dCam = Camera(P=[X, Y, Z], Rc_w=Rc_w, fx=f, fy=f, ppx=ppx, ppy=ppy, 
+     skew=skew, k1=-0.2, k2=0.2, k3=-0.2, rows=rows, cols=cols)
 
 dxy = cameraproject(dCam, [gpt1 gpt2])
 planept = imagept2plane(dCam, dxy, planeP, planeN)

--- a/test/test_projective.jl
+++ b/test/test_projective.jl
@@ -40,12 +40,13 @@ planept = imagept2plane(Cam, xy, planeP, planeN)
 @test maximum(abs.(planept - [gpt1 gpt2])) < f*tol
 
 #same test as above with radial distortion
-Cam.k1=-0.2
-Cam.k2=0.2
-Cam.k3=-0.2
+dCam=deepcopy(Cam)
+dCam.k1=-0.2
+dCam.k2=0.2
+dCam.k3=-0.2
 
-xy = cameraproject(Cam, [gpt1 gpt2])
-planept = imagept2plane(Cam, xy, planeP, planeN,:iterative)
+dxy = cameraproject(dCam, [gpt1 gpt2])
+planept = imagept2plane(dCam, dxy, planeP, planeN)
 @test maximum(abs.(planept - [gpt1 gpt2])) < f*tol
 
 # Convert Cam structure to projection matrix and decompose to see if we get the same parameters back


### PR DESCRIPTION
Here is the PR originating from #31.

I tested the coefficient-based solution from Drap2016 paper linked in that issue, the iterative solution, and a custom least square polynomial fit. 
The iterative solution worked best, so I included only that one. A test with moderate radial distortion coefficient and the reversal was within the `tol=1e-8` boundaries.

In case there is no distortion, it does the same as before and at the same speed.

Image points which do not have a corresponding point on the plane do not converge and can take arbitrary values. Not sure if NaN or something should be returned for these cases. 

I do not know if the inversion of the tangential distortion is handled correctly, though. It seems also like it did not invert the tangential distortion in the current version (before this modification), even if `k1`to `k3` are 0. 

It seems like `imagept2ray` could also need a similar refinement to be consistent for the distortion handling across routines.
