### PR TITLE
[WIP] check visible points are in front of the camera

### DIFF
--- a/src/projective.jl
+++ b/src/projective.jl
@@ -271,7 +271,8 @@ function cameraproject(C::Camera, pta::Array; computevisibility = false)
     if computevisibility
         if C.rows !=0 && C.cols != 0
            visible = (x_p .>= 1.0) .& (x_p .<= convert(Float64,C.cols)) .&
-                     (y_p .>= 1.0) .& (y_p .<= convert(Float64,C.rows))
+                     (y_p .>= 1.0) .& (y_p .<= convert(Float64,C.rows)) .& 
+                     (pt[3:3,:] .>= 0.0) # Make sure points are not behind camera
         else
             @warn("Point visibility requested but Camera structure has no image size data")
             visible = Array{Bool}(undef, 0)


### PR DESCRIPTION
when computing the visibility of points in the `cameraproject` function, also make sure that the points are in front of the camera. This can be easily and cheaply done in this place, as the z position in camera local coordinates is computed during projection.
The weird array syntax (`pt[3:3,:]`) was necessary for performance. Whatever it does...