### PR TITLE
Update DSP compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 ImageProjectiveGeometryPyPlotExt = "PyPlot"
 
 [compat]
-DSP = "0.5 - 0.7"
+DSP = "0.5 - 0.8"
 FileIO = "1"
 ImageFiltering = "0.4 - 0.7"
 Images = "0.20 - 0.25"


### PR DESCRIPTION
### Purpose  
This PR extends the `compat` entries for the DSP package to ensure seamless integration with other packages requiring DSP v0.8+ while preserving backward compatibility.  

### Changes  
- Expanded version bounds in `Project.toml` for `DSP.jl`

### Testing  
- Local tests pass successfully.  
- **Note:** Deprecation warnings were observed, but these are non-critical for current functionality:  
  ```julia
  ┌ Warning: `conv(u::AbstractVector{T}, v::AbstractVector{T}, A::AbstractMatrix{T})` is deprecated, use `conv(u, transpose(v), A)` instead.  
  │   caller = derivative7(...) at utilities.jl:262  
 